### PR TITLE
Asmo-8144 env

### DIFF
--- a/.plans/.editorconfig
+++ b/.plans/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = crlf

--- a/.plans/AGENTS.md
+++ b/.plans/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md for AI Plans
+
+In this folder, we only keep Markdown files for AI plans.
+Each file matches the issueid (e.g. ASMO-7877) as prefix which corresponds to the Jira ID.
+The same issueid is also used by our git feature branches as prefix.
+
+## How to Write Plans
+
+1. Each plan consists of exactly the three following elements: a rationale, acceptance criteria, and technical details.
+2. A rationale describes the overarching goal of the plan. Keep this concise, only elaborate when special circumstances require it. Use free text in this section of the plan.
+3. Acceptance criteria is a list of requirements that must be met for the plan to be considered complete. Use check marks `- [ ]` for these in Markdown.
+4. Technical details describes the changes on a technical level. Which classes and members should be extended, which design patterns should be used? How do we ensure performance? Avoid going into too much detail (do not write the finished implementation), but focus on the high-level design and how things are connected. It should give the implementer a clear picture of what needs to be done, but also give her or him freedom to implement the plan in a way that she or he deems best. The length of this section is highly dependent on the task that the plan addresses.
+5. Regarding automated tests: it is usually enough to note that 'automated tests need to be written' as one check mark in the acceptance criteria list. If there are special requirements for the tests, these can be elaborated in the technical details section. But normally, you can simply leave these technical details out if the automated tests can be written in a straightforward way.

--- a/.plans/ASMO-8144-env-vault-keys.md
+++ b/.plans/ASMO-8144-env-vault-keys.md
@@ -16,34 +16,35 @@ allowlist of name prefixes rather than the entire process environment.
 
 ## Acceptance criteria
 
-- [ ] `getVaultKeys` detects `VaultKey` references that are supplied via `process.env`
+- [x] `getVaultKeys` detects `VaultKey` references that are supplied via `process.env`
       (not only via `.env` files).
-- [ ] Only `process.env` entries whose **name** matches an explicit prefix allowlist are
+- [x] Only `process.env` entries whose **name** matches an explicit prefix allowlist are
       considered; unrelated/system variables are never read.
-- [ ] When the same key is defined in both `process.env` and an `.env` file, the value from
+- [x] When the same key is defined in both `process.env` and an `.env` file, the value from
       `process.env` wins.
-- [ ] Placeholder expansion (e.g. `$Env`) keeps working for both sources.
-- [ ] The function still does not leak or write non-Vault `.env` values into `process.env`
+- [x] Placeholder expansion (e.g. `$Env`) keeps working for both sources.
+- [x] The function still does not leak or write non-Vault `.env` values into `process.env`
       (the existing "values are not added to process.env" guarantee is preserved).
-- [ ] A documented decision on the allowlist approach is captured (see Technical details).
-- [ ] Automated tests are written that prove env variables are resolved and take priority
+- [x] A documented decision on the allowlist approach is captured (see Technical details).
+- [x] Automated tests are written that prove env variables are resolved and take priority
       over the `.env` file.
 
 ## Technical details
 
 ### Change in `src/env.ts` (`getVaultKeys`)
 
-- Introduce an explicit, named prefix allowlist near the top of the module, e.g.:
+- Introduce named constants near the top of the module:
 
   ```ts
+  const vaultKeyPrefix = "VaultKey--";
   const vaultKeyEnvPrefixes = ["Logger_", "MongoDbOptions__", "MongoDb__"];
   ```
 
 - Keep the current file-based detection: parse the files into a temp env and take the
-  `VaultKey`-prefixed entries from `.parsed`.
+  `VaultKey--`-prefixed entries from `.parsed`.
 - Additionally pick entries from `process.env` that pass **two gates**:
   1. the variable **name** starts with one of `vaultKeyEnvPrefixes`, and
-  2. the variable **value** starts with the `VaultKey` sentinel.
+  2. the variable **value** starts with the `vaultKeyPrefix` sentinel.
   Filter by name first so values of non-matching (system/unrelated) variables are never read.
 - Merge the two maps so that **`process.env` overrides the file values** (e.g.
   `{ ...fileVaultValues, ...envVaultValues }`).
@@ -53,16 +54,18 @@ allowlist of name prefixes rather than the entire process environment.
 
 ### Security / design decision: prefix allowlist + value sentinel (two gates)
 
-We limit env scanning to an explicit name-prefix allowlist combined with the existing
-`VaultKey` value sentinel, rather than scanning the whole environment.
+We limit env scanning to an explicit name-prefix allowlist combined with the
+`VaultKey--` value sentinel, rather than scanning the whole environment.
 
 - **Name-prefix allowlist first**: only variables under the app's own config namespaces
   (`Logger_`, `MongoDbOptions__`, `MongoDb__`) are inspected. Values of system/unrelated
   variables (PATH, tokens, CI vars) are never read. This addresses the concern about touching
   every environment variable and any perceived cost/risk of doing so.
-- **Value sentinel second**: among allowlisted names, only values starting with `VaultKey`
+- **Value sentinel second**: among allowlisted names, only values starting with `VaultKey--`
   become Vault lookups. Unused variables under the same prefix that are plain values (e.g.
-  spare `MongoDbOptions__*` not used by this project) are ignored.
+  spare `MongoDbOptions__*` not used by this project) are ignored. The full `VaultKey--` form
+  (not just `VaultKey`) is required deliberately: it matches the vault client's `parseVaultKey`
+  regex, so a value that cannot actually be resolved is never sent to Vault.
 - **No leakage path**: we never log or emit the environment; only resolved key *names* are
   TRACE-logged, never values.
 - **Extensibility**: adding a new namespaced variable requires no code change; adding a new

--- a/.plans/ASMO-8144-env-vault-keys.md
+++ b/.plans/ASMO-8144-env-vault-keys.md
@@ -1,0 +1,83 @@
+# ASMO-8144 – Resolve Vault keys defined via environment variables
+
+## Rationale
+
+Vault references (values starting with the `VaultKey` sentinel) are only resolved when
+they are declared in an `.env` / `.env.local` file. When the same reference is provided
+through a real environment variable, it is silently ignored and never resolved by Vault.
+
+The reason is that `getVaultKeys` in `src/env.ts` detects Vault references from
+`config({ path, processEnv }).parsed`, which contains **only** the values parsed out of the
+`.env` files – never entries that already exist in `process.env`.
+
+Goal: environment variables must also be scanned for Vault references, and they must take
+**priority** over values coming from `.env` files. Scanning must be limited to an explicit
+allowlist of name prefixes rather than the entire process environment.
+
+## Acceptance criteria
+
+- [ ] `getVaultKeys` detects `VaultKey` references that are supplied via `process.env`
+      (not only via `.env` files).
+- [ ] Only `process.env` entries whose **name** matches an explicit prefix allowlist are
+      considered; unrelated/system variables are never read.
+- [ ] When the same key is defined in both `process.env` and an `.env` file, the value from
+      `process.env` wins.
+- [ ] Placeholder expansion (e.g. `$Env`) keeps working for both sources.
+- [ ] The function still does not leak or write non-Vault `.env` values into `process.env`
+      (the existing "values are not added to process.env" guarantee is preserved).
+- [ ] A documented decision on the allowlist approach is captured (see Technical details).
+- [ ] Automated tests are written that prove env variables are resolved and take priority
+      over the `.env` file.
+
+## Technical details
+
+### Change in `src/env.ts` (`getVaultKeys`)
+
+- Introduce an explicit, named prefix allowlist near the top of the module, e.g.:
+
+  ```ts
+  const vaultKeyEnvPrefixes = ["Logger_", "MongoDbOptions__", "MongoDb__"];
+  ```
+
+- Keep the current file-based detection: parse the files into a temp env and take the
+  `VaultKey`-prefixed entries from `.parsed`.
+- Additionally pick entries from `process.env` that pass **two gates**:
+  1. the variable **name** starts with one of `vaultKeyEnvPrefixes`, and
+  2. the variable **value** starts with the `VaultKey` sentinel.
+  Filter by name first so values of non-matching (system/unrelated) variables are never read.
+- Merge the two maps so that **`process.env` overrides the file values** (e.g.
+  `{ ...fileVaultValues, ...envVaultValues }`).
+- Run the existing `expand({ parsed, processEnv: tempEnv })` on the merged map so that
+  placeholders resolve against the combined environment, then `invert` the result as before.
+- Guard against non-string values when applying `startsWith`.
+
+### Security / design decision: prefix allowlist + value sentinel (two gates)
+
+We limit env scanning to an explicit name-prefix allowlist combined with the existing
+`VaultKey` value sentinel, rather than scanning the whole environment.
+
+- **Name-prefix allowlist first**: only variables under the app's own config namespaces
+  (`Logger_`, `MongoDbOptions__`, `MongoDb__`) are inspected. Values of system/unrelated
+  variables (PATH, tokens, CI vars) are never read. This addresses the concern about touching
+  every environment variable and any perceived cost/risk of doing so.
+- **Value sentinel second**: among allowlisted names, only values starting with `VaultKey`
+  become Vault lookups. Unused variables under the same prefix that are plain values (e.g.
+  spare `MongoDbOptions__*` not used by this project) are ignored.
+- **No leakage path**: we never log or emit the environment; only resolved key *names* are
+  TRACE-logged, never values.
+- **Extensibility**: adding a new namespaced variable requires no code change; adding a new
+  namespace is a one-line edit to `vaultKeyEnvPrefixes`.
+- Prefix note: use `Logger_` (single underscore) to match existing variables such as
+  `Logger_LogFile` and `Logger_ClientUrl`.
+
+### Tests (`src/__tests__/env.spec.ts`)
+
+Add cases that set the relevant variables on `process.env` inside the test (with cleanup so
+tests stay isolated):
+
+- Vault key defined **only** via `process.env` (under an allowed prefix) is returned.
+- Vault key defined in **both** `.env` file and `process.env` returns the value from
+  `process.env` (priority check).
+- Non-`VaultKey` env variables under an allowed prefix are ignored.
+- A `VaultKey` value under a **non-allowlisted** name prefix is ignored.
+- The existing test (file-only detection) keeps passing unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Root Agents.md
+
+migrate-mongo-sag is a database migration tool for MongoDB.
+Read ./README.md for more details if required.
+
+# Implementation rules
+
+Plans typically have acceptance criteria with check boxes. Check each box when you are finished with the corresponding criterion.
+
+# General rules
+
+The projects is written in typescript.
+
+## Conventions
+
+Branch names follow the pattern `ASMO-XXXX-ticket-title`, where `ASMO-XXXX` is the Jira issue ID.
+
+# Plan Rules
+
+Read ./.plans/AGENTS.md for details on how to write plans.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Please read AGENTS.md

--- a/src/__tests__/.env.test
+++ b/src/__tests__/.env.test
@@ -1,4 +1,4 @@
 Env=dev
-MongoDb__User="VaultKey--kv-v2/data/mongodb/$Env/UserName"
-MongoDb__Pass="VaultKey--kv-v2/data/mongodb/$Env/Password"
+MongoDb__User="VaultKey--kv-v2/data/mongodb/ENV-FILE/$Env/UserName"
+MongoDb__Pass="VaultKey--kv-v2/data/mongodb/ENV-FILE/$Env/Password"
 MongoDb__Url="mongodb://{$MongoDb__User}:${MongoDb__Pass}@localhost:27017"

--- a/src/__tests__/env.spec.ts
+++ b/src/__tests__/env.spec.ts
@@ -1,12 +1,24 @@
 import { getVaultKeys } from "../env";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import path from "path";
+
+const envPath = [path.join(__dirname, ".env.test")];
+
+// keys set on process.env during a test; cleaned up afterwards to keep tests isolated
+const managedKeys: string[] = [];
+
+function setEnv(key: string, value: string) {
+    managedKeys.push(key);
+    process.env[key] = value;
+}
+
+afterEach(() => {
+    for (const key of managedKeys) delete process.env[key];
+    managedKeys.length = 0;
+});
 
 describe("getVaultKeys", () => {
     it("should return all vaultKeys that are defined in env files", () => {
-        // arrange
-        const envPath = [path.join(__dirname, ".env.test")];
-
         // act
         const result = getVaultKeys(envPath);
 
@@ -15,11 +27,79 @@ describe("getVaultKeys", () => {
             "VaultKey--kv-v2/data/mongodb/dev/Password": "MongoDb__Pass",
             "VaultKey--kv-v2/data/mongodb/dev/UserName": "MongoDb__User"
         });
+    });
 
-        // assert that .env values are not added to process.env
+    it("should not modify process.env when resolving vault keys from files and env vars", () => {
+        // arrange: env-provided vault key with a placeholder ($Env) defined in the file
+        setEnv("MongoDbOptions__AdminUserName", "VaultKey--kv-v2/data/mongodb/$Env/UserName");
+
+        // act
+        getVaultKeys(envPath);
+
+        // assert .env file values are not added to process.env
         expect(process.env).not.toHaveProperty("Env");
         expect(process.env).not.toHaveProperty("MongoDb__User");
         expect(process.env).not.toHaveProperty("MongoDb__Pass");
         expect(process.env).not.toHaveProperty("MongoDb__Url");
+
+        // assert the env var itself was not expanded/mutated in place
+        expect(process.env.MongoDbOptions__AdminUserName).toBe("VaultKey--kv-v2/data/mongodb/$Env/UserName");
+    });
+
+    it("should detect vaultKeys defined via environment variables", () => {
+        // arrange: vault key only present in process.env under an allowed prefix
+        setEnv("MongoDbOptions__AdminPassword", "VaultKey--kv-v2/data/mongodb/Password");
+
+        // act
+        const result = getVaultKeys(envPath);
+
+        // assert env vault key is resolved in addition to the file ones
+        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/Password", "MongoDbOptions__AdminPassword");
+    });
+
+    it("should let environment variables take priority over env files", () => {
+        // arrange: same key exists in .env.test (expands to .../dev/UserName)
+        setEnv("MongoDb__User", "VaultKey--kv-v2/data/mongodb/prod/UserName");
+
+        // act
+        const result = getVaultKeys(envPath);
+
+        // assert env value wins and the file value is not present
+        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/prod/UserName", "MongoDb__User");
+        expect(result).not.toHaveProperty("VaultKey--kv-v2/data/mongodb/dev/UserName");
+    });
+
+    it("should expand placeholders in vaultKeys defined via environment variables", () => {
+        // arrange: env-provided vault key with a placeholder ($Env) defined in the file
+        setEnv("MongoDbOptions__AdminUserName", "VaultKey--kv-v2/data/mongodb/$Env/UserName");
+
+        // act
+        const result = getVaultKeys(envPath);
+
+        // assert the placeholder was resolved using the file's Env=dev
+        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/dev/UserName", "MongoDbOptions__AdminUserName");
+    });
+
+    it("should ignore non-VaultKey environment variables under an allowed prefix", () => {
+        // arrange
+        setEnv("MongoDbOptions__DatabaseHost", "localhost");
+
+        // act
+        const result = getVaultKeys(envPath);
+
+        // assert plain value is not treated as a vault key
+        expect(Object.values(result)).not.toContain("MongoDbOptions__DatabaseHost");
+    });
+
+    it("should ignore VaultKey values under a non-allowlisted name prefix", () => {
+        // arrange
+        setEnv("SomeOther__Secret", "VaultKey--kv-v2/data/other/Secret");
+
+        // act
+        const result = getVaultKeys(envPath);
+
+        // assert the non-allowlisted variable is not resolved
+        expect(result).not.toHaveProperty("VaultKey--kv-v2/data/other/Secret");
+        expect(Object.values(result)).not.toContain("SomeOther__Secret");
     });
 });

--- a/src/__tests__/env.spec.ts
+++ b/src/__tests__/env.spec.ts
@@ -24,14 +24,14 @@ describe("getVaultKeys", () => {
 
         // assert that list of vaultKeys is returned
         expect(result).toStrictEqual({
-            "VaultKey--kv-v2/data/mongodb/dev/Password": "MongoDb__Pass",
-            "VaultKey--kv-v2/data/mongodb/dev/UserName": "MongoDb__User"
+            "VaultKey--kv-v2/data/mongodb/ENV-FILE/dev/Password": "MongoDb__Pass",
+            "VaultKey--kv-v2/data/mongodb/ENV-FILE/dev/UserName": "MongoDb__User"
         });
     });
 
     it("should not modify process.env when resolving vault keys from files and env vars", () => {
         // arrange: env-provided vault key with a placeholder ($Env) defined in the file
-        setEnv("MongoDbOptions__AdminUserName", "VaultKey--kv-v2/data/mongodb/$Env/UserName");
+        setEnv("MongoDbOptions__AdminUserName", "VaultKey--kv-v2/data/mongodb/ENV-VAR/$Env/UserName");
 
         // act
         getVaultKeys(envPath);
@@ -43,41 +43,42 @@ describe("getVaultKeys", () => {
         expect(process.env).not.toHaveProperty("MongoDb__Url");
 
         // assert the env var itself was not expanded/mutated in place
-        expect(process.env.MongoDbOptions__AdminUserName).toBe("VaultKey--kv-v2/data/mongodb/$Env/UserName");
+        expect(process.env.MongoDbOptions__AdminUserName).toBe("VaultKey--kv-v2/data/mongodb/ENV-VAR/$Env/UserName");
     });
 
     it("should detect vaultKeys defined via environment variables", () => {
         // arrange: vault key only present in process.env under an allowed prefix
-        setEnv("MongoDbOptions__AdminPassword", "VaultKey--kv-v2/data/mongodb/Password");
+        setEnv("MongoDbOptions__AdminPassword", "VaultKey--kv-v2/data/mongodb/ENV-VAR/Password");
 
         // act
         const result = getVaultKeys(envPath);
 
         // assert env vault key is resolved in addition to the file ones
-        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/Password", "MongoDbOptions__AdminPassword");
+        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/ENV-VAR/Password", "MongoDbOptions__AdminPassword");
     });
 
     it("should let environment variables take priority over env files", () => {
-        // arrange: same key exists in .env.test (expands to .../dev/UserName)
-        setEnv("MongoDb__User", "VaultKey--kv-v2/data/mongodb/prod/UserName");
+        // arrange: same key (MongoDb__User) exists in .env.test (resolves to .../ENV-FILE/dev/UserName);
+        // override it via process.env with a distinguishable ENV-VAR path
+        setEnv("MongoDb__User", "VaultKey--kv-v2/data/mongodb/ENV-VAR/prod/UserName");
 
         // act
         const result = getVaultKeys(envPath);
 
         // assert env value wins and the file value is not present
-        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/prod/UserName", "MongoDb__User");
-        expect(result).not.toHaveProperty("VaultKey--kv-v2/data/mongodb/dev/UserName");
+        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/ENV-VAR/prod/UserName", "MongoDb__User");
+        expect(result).not.toHaveProperty("VaultKey--kv-v2/data/mongodb/ENV-FILE/dev/UserName");
     });
 
     it("should expand placeholders in vaultKeys defined via environment variables", () => {
         // arrange: env-provided vault key with a placeholder ($Env) defined in the file
-        setEnv("MongoDbOptions__AdminUserName", "VaultKey--kv-v2/data/mongodb/$Env/UserName");
+        setEnv("MongoDbOptions__AdminUserName", "VaultKey--kv-v2/data/mongodb/ENV-VAR/$Env/UserName");
 
         // act
         const result = getVaultKeys(envPath);
 
         // assert the placeholder was resolved using the file's Env=dev
-        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/dev/UserName", "MongoDbOptions__AdminUserName");
+        expect(result).toHaveProperty("VaultKey--kv-v2/data/mongodb/ENV-VAR/dev/UserName", "MongoDbOptions__AdminUserName");
     });
 
     it("should ignore non-VaultKey environment variables under an allowed prefix", () => {
@@ -93,13 +94,13 @@ describe("getVaultKeys", () => {
 
     it("should ignore VaultKey values under a non-allowlisted name prefix", () => {
         // arrange
-        setEnv("SomeOther__Secret", "VaultKey--kv-v2/data/other/Secret");
+        setEnv("SomeOther__Secret", "VaultKey--kv-v2/data/other/ENV-VAR/Secret");
 
         // act
         const result = getVaultKeys(envPath);
 
         // assert the non-allowlisted variable is not resolved
-        expect(result).not.toHaveProperty("VaultKey--kv-v2/data/other/Secret");
+        expect(result).not.toHaveProperty("VaultKey--kv-v2/data/other/ENV-VAR/Secret");
         expect(Object.values(result)).not.toContain("SomeOther__Secret");
     });
 });

--- a/src/__tests__/logger.spec.ts
+++ b/src/__tests__/logger.spec.ts
@@ -1,0 +1,30 @@
+import { initLogger, getLogFile, defaultLogFile } from "../logger";
+import { describe, it, expect, afterEach } from "vitest";
+
+const logKeys = ["Logger_LogFile", "Logger_LogLevel"];
+
+afterEach(() => {
+    for (const key of logKeys) delete process.env[key];
+});
+
+describe("logger", () => {
+    it("should initialize without throwing when log env values are unset", () => {
+        // arrange: simulate a failed initEnv where no Logger_* values were loaded
+        for (const key of logKeys) delete process.env[key];
+
+        // act + assert: winston must not crash on a missing filename
+        expect(() => initLogger()).not.toThrow();
+    });
+
+    it("should fall back to the default log file when Logger_LogFile is unset", () => {
+        delete process.env.Logger_LogFile;
+
+        expect(getLogFile()).toBe(defaultLogFile);
+    });
+
+    it("should use Logger_LogFile when it is set", () => {
+        process.env.Logger_LogFile = "custom/path.json";
+
+        expect(getLogFile()).toBe("custom/path.json");
+    });
+});

--- a/src/elasticClient.ts
+++ b/src/elasticClient.ts
@@ -2,6 +2,7 @@ import { Client } from "@elastic/elasticsearch";
 import { format } from "date-fns";
 import fs from "fs";
 import readline from "readline";
+import { getLogFile } from "./logger";
 
 export default class ElasticClient {
     private client = initElasticClient();
@@ -11,7 +12,7 @@ export default class ElasticClient {
             return;
         }
 
-        const fileStream = fs.createReadStream(process.env.Logger_LogFile);
+        const fileStream = fs.createReadStream(getLogFile());
         const lines = readline.createInterface({
             input: fileStream,
             crlfDelay: Infinity

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,7 +22,6 @@ export async function initEnv(cmd: Command) {
         await loadBranchName();
         await loadVault();
         await loadEnvFiles();
-        loadLogValues();
 
         if (process.env.TRACE) console.log("finished init env");
     } catch (error) {
@@ -102,16 +101,4 @@ export function loadBranchName() {
     populate(process.env, parsed);
 
     if (process.env.TRACE) console.log("set branch", parsed);
-}
-
-export function loadLogValues() {
-    const defaultLogLevel = "info";
-    const defaultLogFile = "logs/log.json";
-
-    const defaultLogValues = {
-        Logger_LogFile: process.env.Logger_LogFile || defaultLogFile,
-        Logger_LogLevel: process.env.Logger_LogLevel || defaultLogLevel
-    };
-
-    populate(process.env, defaultLogValues);
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,18 +15,14 @@ const vaultKeyPrefix = "VaultKey--";
 const vaultKeyEnvPrefixes = ["Logger_", "MongoDbOptions__", "MongoDb__"];
 
 export async function initEnv(cmd: Command) {
-    try {
-        if (process.env.TRACE) console.log("int env...");
+    if (process.env.TRACE) console.log("int env...");
 
-        await loadCommand(cmd);
-        await loadBranchName();
-        await loadVault();
-        await loadEnvFiles();
+    await loadCommand(cmd);
+    await loadBranchName();
+    await loadVault();
+    await loadEnvFiles();
 
-        if (process.env.TRACE) console.log("finished init env");
-    } catch (error) {
-        console.error(`init env failed`, error);
-    }
+    if (process.env.TRACE) console.log("finished init env");
 }
 
 export function loadEnvFiles() {

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,6 +8,12 @@ import type { Command } from "commander";
 // define files to load
 const path = [".env.local", ".env"];
 
+// the sentinel a value must start with to be treated as a VaultKey reference
+const vaultKeyPrefix = "VaultKey--";
+
+// only environment variables under these name prefixes are scanned for VaultKey references; so unrelated/system variables are never read
+const vaultKeyEnvPrefixes = ["Logger_", "MongoDbOptions__", "MongoDb__"];
+
 export async function initEnv(cmd: Command) {
     try {
         if (process.env.TRACE) console.log("int env...");
@@ -47,7 +53,15 @@ export function getVaultKeys(path: string[]) {
     // load env for vault to temporary env; otherwise placeholders that target a field with VaultKey would be replaced before VaultValues are loaded
     const tempEnv = clone(process.env);
     const vaultEnv = config({ path, processEnv: tempEnv });
-    const vaultValues = pickBy(vaultEnv.parsed, (value) => value.startsWith("VaultKey"));
+
+    const isValueVaultKey = (value: string | undefined) => typeof value === "string" && value.startsWith(vaultKeyPrefix);
+    const isEnvPrefixAllowed = (key: string) => vaultKeyEnvPrefixes.some((prefix) => key.startsWith(prefix));
+
+    // collect VaultKey references from .env files and from process.env (env takes priority).
+    const fileVaultValues = pickBy(vaultEnv.parsed, (value) => isValueVaultKey(value));
+    const envVaultValues = pickBy(process.env, (value, key) => isEnvPrefixAllowed(key) && isValueVaultKey(value));
+    const vaultValues = { ...fileVaultValues, ...envVaultValues };
+
     const vaultEnvExpanded = expand({ parsed: vaultValues, processEnv: tempEnv });
 
     return invert(vaultEnvExpanded.parsed);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,23 @@ program
 program.hook("preSubcommand", async (cmd) => {
     process.env.TRACE = cmd.getOptionValue("trace") ? "on" : "";
     if (process.env.TRACE) console.log("hook pre-command...");
-    await initEnv(cmd);
-    logger = initLogger();
-    elasticClient = new ElasticClient();
+
+    try {
+        await initEnv(cmd);
+    } catch (error) {
+        // env init (e.g. vault) failed; abort cleanly instead of running the command with broken config
+        console.error("init env failed", error);
+        process.exit(1);
+    }
+
+    try {
+        logger = initLogger();
+        elasticClient = new ElasticClient();
+    } catch (error) {
+        // without a logger the commands cannot run; abort cleanly instead of crashing with an unhandled rejection
+        console.error("init logger failed", error);
+        process.exit(1);
+    }
 });
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ program
 
         try {
             const deleteStatus = await deleteDb(db);
-            logger.info(`DROPPED DB:`, deleteStatus.databaseName, deleteStatus.userName);
+            logger.info(`DROPPED DB: ${deleteStatus.databaseName}, user: ${deleteStatus.userName}`);
         } catch (error) {
             logger.error(`ERROR: ${error.message}`, error.stack);
             hasError = 1;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,9 @@ import ecsFormat from "@elastic/ecs-winston-format";
 import winston, { format } from "winston";
 import { name, version } from "../package.json";
 
+export const defaultLogFile = "logs/log.json";
+export const defaultLogLevel = "info";
+
 export function initLogger() {
     const consoleLog = new winston.transports.Console({
         format: format.simple()
@@ -22,14 +25,24 @@ export function initLogger() {
     })();
 
     const fileLog = new winston.transports.File({
-        filename: process.env.Logger_LogFile,
+        filename: getLogFile(),
         format: format.combine(fieldsFormat, ecsJsonFormat)
     });
 
     const logger = winston.createLogger({
-        level: process.env.Logger_LogLevel,
+        level: getLogLevel(),
         transports: [consoleLog, fileLog]
     });
 
     return logger;
+}
+
+// resolve log config with defaults so logging works even when env init did not complete;
+// getLogFile is shared with the elastic sync so both read the same file
+export function getLogFile() {
+    return process.env.Logger_LogFile || defaultLogFile;
+}
+
+export function getLogLevel() {
+    return process.env.Logger_LogLevel || defaultLogLevel;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,30 +1795,30 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 
@@ -3516,13 +3516,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -4915,15 +4915,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
+  checksum: 10c0/7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## ASMO-8144 — Vault keys via env vars, logging robustness & CVE fixes

### Summary

Adds support for defining Vault keys through environment variables, hardens logger
initialization so it can't crash on incomplete/failed env setup, fixes the
`dropDatabase` log output, and pulls in security patches for three transitive
dependencies.

### Changes

#### Vault keys via environment variables (ASMO-8144)

- `getVaultKeys` now resolves `VaultKey--` references supplied through `process.env`,
  not just `.env` files. Env values take **priority** over file values.
- Scanning is limited to an explicit name-prefix allowlist (`Logger_`,
  `MongoDbOptions__`, `MongoDb__`) combined with the `VaultKey--` value sentinel, so
  unrelated/system variables are never read.
- Plan documented in `.plans/ASMO-8144-env-vault-keys.md`; unit tests cover env-only
  resolution, env-over-file priority, no-mutation of `process.env`, and both allowlist
  gates.

#### Logger crash on failed env init (#31)

- Made the logger self-sufficient: log file/level defaults now resolve in `logger.ts`
  via `getLogFile()` / `getLogLevel()` (the file path is shared with the Elastic sync
  so both read the same file). Removed the redundant `loadLogValues` from `env.ts`.
- Fixes the winston `Cannot log to file without filename or stream.` crash that
  occurred when `initEnv` aborted (e.g. bad vault key) before log defaults were applied.

#### Clean shutdown (#31)

- `initEnv` no longer swallows errors; the `preSubcommand` hook now logs and `exit(1)`s
  on env or logger/elastic setup failure, instead of continuing with broken config and
  failing again at `database.connect`.

#### dropDatabase logging (#33)

- The database name and user were passed as extra `logger.info` args, which winston
  treats as splat metadata and `format.simple()` drops. Interpolated them into the
  message string like the other commands.

#### Security — dependency updates

- `brace-expansion` → 1.1.16 / 2.1.2 / 5.0.7 — CVE-2026-13149 (GHSA-3jxr-9vmj-r5cp)
- `js-yaml` → 4.3.0 — CVE-2026-59869 (GHSA-52cp-r559-cp3m)
- `tar` → CVE fix (GHSA-8x88-c5mf-7j5w)

### Usage

Any allowlisted setting can now be overridden via an environment variable, which takes
priority over the `.env` file. For example, to point a MongoDB vault key at a different
secret path on helm chart or locally on powershell.

```powershell
# override a MongoDb setting via env var (wins over .env)
$env:MongoDbOptions__AdminPassword = 'VaultKey--kv-v2/data/mongodb/prod/Password'
yarn migrate-mongo status